### PR TITLE
Beginning of db creation in SQL

### DIFF
--- a/backend/db_scripts/create-db.sql
+++ b/backend/db_scripts/create-db.sql
@@ -1,0 +1,6 @@
+CREATE DATABASE platform;
+/*
+connecting to the new db in psql: 
+\connect platform
+*/
+CREATE SCHEMA platform;

--- a/backend/db_scripts/create-tables.sql
+++ b/backend/db_scripts/create-tables.sql
@@ -1,0 +1,37 @@
+CREATE TABLE platform.topics (
+	id serial NOT NULL,
+	topic text NOT NULL, 
+	PRIMARY KEY (id),
+	CONSTRAINT unique_topic UNIQUE(topic)
+);
+
+CREATE TABLE platform.terms (
+	id serial NOT NULL,
+	term text NOT NULL,
+	PRIMARY KEY (id),
+	CONSTRAINT unique_term UNIQUE(term)
+);
+
+-- bridge table for terms and topics
+CREATE TABLE platform.terms_to_topics (
+	term_id int NOT NULL,
+	topic_id int NOT NULL,
+	FOREIGN KEY (term_id) REFERENCES platform.terms(id),
+	FOREIGN KEY (topic_id) REFERENCES platform.topics(id),
+	UNIQUE(term_id, topic_id)
+);
+
+/*
+I defined each question as only corresponding to a single topic.
+If we want to change that, we can set up another bridge table for 
+questions to topics. 
+*/
+CREATE TABLE platform.questions (
+	id serial NOT NULL,
+	question text NOT NULL,
+	topic_id int NOT NULL,
+	PRIMARY KEY (id),
+	FOREIGN KEY (topic_id) REFERENCES platform.topics(id), 
+	CONSTRAINT unique_question UNIQUE(question)
+);
+

--- a/backend/db_scripts/inserting-data.sql
+++ b/backend/db_scripts/inserting-data.sql
@@ -1,6 +1,7 @@
 -- we don't need to specify the `id` column bc it is serial 
 -- so it will auto-increment
 INSERT INTO platform.topics (topic) VALUES ('new topic');
+INSERT INTO platform.topics (topic) VALUES ('neoliberalism');
 
 
 INSERT INTO platform.terms (term) VALUES ('new term');

--- a/backend/db_scripts/inserting-data.sql
+++ b/backend/db_scripts/inserting-data.sql
@@ -1,0 +1,21 @@
+-- we don't need to specify the `id` column bc it is serial 
+-- so it will auto-increment
+INSERT INTO platform.topics (topic) VALUES ('new topic');
+
+
+INSERT INTO platform.terms (term) VALUES ('new term');
+INSERT INTO platform.terms (term) VALUES ('new term 2');
+INSERT INTO platform.terms (term) VALUES ('new term 3');
+
+/*
+For now we manually need to update the bridge table.
+We can later set up a trigger to do this, or ensure the function that updates
+these tables in the code makes the required updates.
+*/
+INSERT INTO platform.terms_to_topics (term_id, topic_id) VALUES (1, 1),
+(2, 1);
+INSERT INTO platform.terms_to_topics (term_id, topic_id) VALUES (3, 2);
+
+
+
+INSERT INTO platform.questions (question, topic_id) VALUES ('question about new topic', 1);

--- a/backend/db_scripts/list-indexes.sql
+++ b/backend/db_scripts/list-indexes.sql
@@ -1,0 +1,22 @@
+/*
+List indexes in the platform schema
+*/
+SELECT
+    tablename,
+    indexname,
+    indexdef
+FROM
+    pg_indexes
+WHERE
+    schemaname = 'platform'
+ORDER BY
+    tablename,
+    indexname;
+
+/*
+Example output showing that indexes get created when PRIMARY KEY 
+and UNIQUE() constraints are specified in the table definition. 
+
+"topics"	"topics_pkey"	"CREATE UNIQUE INDEX topics_pkey ON platform.topics USING btree (id)"
+"topics"	"unique_topic"	"CREATE UNIQUE INDEX unique_topic ON platform.topics USING btree (topic)"
+*/

--- a/backend/db_scripts/retrieving-data.sql
+++ b/backend/db_scripts/retrieving-data.sql
@@ -1,0 +1,39 @@
+select * from platform.topics;
+/*
+sample output:
+"id"	"topic"
+1	"new topic"
+2	"neoliberalism"
+*/
+
+select * from platform.terms;
+/*
+"id"	"term"
+1	"new term"
+2	"new term 2"
+3	"new term 3"
+*/
+
+
+select * from platform.terms_to_topics;
+/*
+"term_id"	"topic_id"
+1	1
+2	1
+3	2
+*/
+
+-- get all terms that corresopnd to 'new topic' (term_id: 1)
+select * from platform.terms_to_topics where term_id = 1;
+/*
+"term_id"	"topic_id"
+1	1
+2	1
+*/
+
+
+select * from platform.questions;
+/*
+"id"	"question"	"topic_id"
+1	"question about new topic"	1
+*/


### PR DESCRIPTION
* was going off of the DB model shared in the chat 
* major finding was that we should update the schema to have bridge tables instead of arrays of integers of foreign keys

Didn't have time to finish writing the SQL for the rest of the tables, but the overall relationship between them makes sense to me so far.

Also in a future PR will probably try to set up docker so that we can start up a sample DB on command with these script so we have some sample data for the API to work off of.