### PR TITLE
Replace unwrap with expect

### DIFF
--- a/backend/crm_api/src/lib.rs
+++ b/backend/crm_api/src/lib.rs
@@ -4,12 +4,11 @@ use routes::create_routes;
 use sqlx::postgres::PgPoolOptions;
 
 pub async fn run(db_uri: &str) {
-    // TODO: replace unwrap with `?` and handle potential error response from Result<>
     let pool = PgPoolOptions::new()
         .max_connections(5)
         .connect(db_uri)
         .await
-        .unwrap();
+        .expect("db pool failed to initialize");
 
     // build our server/application
     let app: Router = create_routes(pool);
@@ -19,5 +18,5 @@ pub async fn run(db_uri: &str) {
     axum::Server::bind(&"0.0.0.0:3000".parse().unwrap())
         .serve(app.into_make_service())
         .await
-        .unwrap();
+        .expect("server failed to start");
 }

--- a/backend/crm_api/src/main.rs
+++ b/backend/crm_api/src/main.rs
@@ -5,6 +5,8 @@ use std::env;
 #[tokio::main]
 async fn main() {
     dotenv().ok();
-    let db_uri = env::var("DATABASE_URL").unwrap();
+    let db_uri = env::var("DATABASE_URL").expect(
+        "DATABASE_URL env var is required for connecting to the db and for sqlx macros"
+    );
     run(&db_uri).await
 }

--- a/backend/crm_api/src/routes/terms.rs
+++ b/backend/crm_api/src/routes/terms.rs
@@ -40,7 +40,7 @@ pub async fn get_all_terms_for_topic_handler(
 ) -> Json<Vec<Term>> {
     let terms = get_all_terms_for_a_topic(&db_pool, &params.topic)
         .await
-        .expect("failed ot retrieve terms for a given topic");
+        .expect("failed to retrieve terms for a given topic");
     Json(terms)
 }
 

--- a/backend/crm_api/src/routes/terms.rs
+++ b/backend/crm_api/src/routes/terms.rs
@@ -14,7 +14,9 @@ pub struct QueryParams {
 }
 
 pub async fn get_all_terms_handler(State(db_pool): State<PgPool>) -> Json<Vec<Term>> {
-    let terms = get_all_terms(&db_pool).await.unwrap();
+    let terms = get_all_terms(&db_pool)
+        .await
+        .expect("failed to retrieve terms");
     Json(terms)
 }
 
@@ -38,7 +40,7 @@ pub async fn get_all_terms_for_topic_handler(
 ) -> Json<Vec<Term>> {
     let terms = get_all_terms_for_a_topic(&db_pool, &params.topic)
         .await
-        .unwrap();
+        .expect("failed ot retrieve terms for a given topic");
     Json(terms)
 }
 

--- a/backend/crm_api/src/routes/topics.rs
+++ b/backend/crm_api/src/routes/topics.rs
@@ -23,7 +23,7 @@ pub struct CreateTopic {
 - returns all topics
  */
 pub async fn get_all_topics_handler(State(db_pool): State<PgPool>) -> Json<Vec<Topic>> {
-    let topics = get_all_topics(&db_pool).await.unwrap();
+    let topics = get_all_topics(&db_pool).await.expect("failed to retrieve topics");
     Json(topics)
 }
 


### PR DESCRIPTION
Working through the rust book and came across a section on the difference between `unwrap` and `expect` and expect appears to be the more appropriate option here: 

```
We use expect in the same way as unwrap: to return the file handle or call the panic! macro. The error message used by expect in its call to panic! will be the parameter that we pass to expect, rather than the default panic! message that unwrap uses.
```