### PR TITLE
Update Error Handling for Handler functions

### DIFF
--- a/backend/crm_api/src/routes/topics.rs
+++ b/backend/crm_api/src/routes/topics.rs
@@ -33,7 +33,7 @@ pub async fn get_all_topics_handler(State(db_pool): State<PgPool>) -> Response {
 }
 
 pub async fn get_all_topics(db_pool: &PgPool) -> Result<Vec<Topic>> {
-    let topics = sqlx::query_as::<_, Topic>("SELECT id, topic FROM platform.tipics")
+    let topics = sqlx::query_as::<_, Topic>("SELECT id, topic FROM platform.topics")
         .fetch_all(db_pool)
         .await?;
     Ok(topics)

--- a/backend/crm_api/src/routes/topics.rs
+++ b/backend/crm_api/src/routes/topics.rs
@@ -22,16 +22,20 @@ pub struct CreateTopic {
  /topics
 - returns all topics
  */
-pub async fn get_all_topics_handler(State(db_pool): State<PgPool>) -> Json<Vec<Topic>> {
-    let topics = get_all_topics(&db_pool).await.expect("failed to retrieve topics");
-    Json(topics)
+pub async fn get_all_topics_handler(State(db_pool): State<PgPool>) -> Response {
+    let topics = get_all_topics(&db_pool).await;
+    match topics {
+        Ok(topics) => (StatusCode::OK, Json(topics)).into_response(),
+        // for errors Axum expects the axum::response::Response type
+        // example output: error returned from database: relation "platform.tipics" does not exist
+        Err(error) => (StatusCode::INTERNAL_SERVER_ERROR, error.to_string()).into_response()
+    }
 }
 
 pub async fn get_all_topics(db_pool: &PgPool) -> Result<Vec<Topic>> {
-    let topics = sqlx::query_as::<_, Topic>("SELECT id, topic FROM platform.topics")
+    let topics = sqlx::query_as::<_, Topic>("SELECT id, topic FROM platform.tipics")
         .fetch_all(db_pool)
         .await?;
-
     Ok(topics)
 }
 
@@ -46,13 +50,13 @@ pub async fn new_topic_handler(
     State(db_pool): State<PgPool>,
     Json(payload): Json<CreateTopic>,
 ) -> Response {
+    // TODO: add definition to topic creation!
     let topic = &payload.topic;
     let insert_result = query!("INSERT INTO platform.topics (topic) VALUES ($1)", topic)
         .execute(&db_pool)
         .await;
-    let insert = match insert_result {
+    match insert_result {
         Ok(_insert_result) => "new topic created".into_response(),
-        Err(_err) => (StatusCode::INTERNAL_SERVER_ERROR, "Insertion to DB failed").into_response(),
-    };
-    insert
+        Err(error) => (StatusCode::INTERNAL_SERVER_ERROR, error.to_string()).into_response(),
+    }
 }


### PR DESCRIPTION
Previously if there were uncaught exceptions within the handlers, it could potentially result in `panics` being thrown and the server shutting down. Now, it should just return an error message to the end user along with a 500 status code.

Example output from `/terms` when there is a SQL error: 
```
error returned from database: relation "platform.tirms" does not exist
```