### PR TITLE
updated POST `/new-topic` endpoint to include all optional vec fields

### DIFF
--- a/backend/crm_api/src/routes/topics.rs
+++ b/backend/crm_api/src/routes/topics.rs
@@ -30,14 +30,14 @@ pub struct CreateTopic {
     is_verified: Option<bool>, 
     brief_description: Option<String>,
     full_description: Option<String>,
-    // bullet_points: Option<Vec<String>>,
-    // examples: Option<Vec<String>>,
-    // parallels: Option<Vec<String>>,
+    bullet_points: Option<Vec<String>>,
+    examples: Option<Vec<String>>,
+    parallels: Option<Vec<String>>,
     ai_brief_description: Option<String>,
     ai_full_description: Option<String>,
-    // ai_bullet_points: Option<Vec<String>>,
-    // ai_parallels: Option<Vec<String>>,
-    // ai_examples: Option<Vec<String>>,
+    ai_bullet_points: Option<Vec<String>>,
+    ai_parallels: Option<Vec<String>>,
+    ai_examples: Option<Vec<String>>,
 }
 
 /*
@@ -64,6 +64,14 @@ pub async fn get_all_topics(db_pool: &PgPool) -> Result<Vec<Topic>> {
     Ok(topics)
 }
 
+pub fn process_optional_param(param: Option<Vec<String>>) -> Vec<String> {
+    let mut processed_param = vec![];
+    if let Some(populated_param) = param {
+        processed_param = populated_param
+    }
+    processed_param
+}
+
 /*
 /new-topic
 Body:
@@ -75,15 +83,28 @@ pub async fn new_topic_handler(
     State(db_pool): State<PgPool>,
     Json(payload): Json<CreateTopic>,
 ) -> Response {
-    // TODO: look into how to insert Vecs into the INSERT SQL statement...
+    let bullet_points = process_optional_param(payload.bullet_points);
+    let examples = process_optional_param(payload.examples);
+    let parallels = process_optional_param(payload.parallels);
+    let ai_bullet_points = process_optional_param(payload.ai_bullet_points);
+    let ai_parallels = process_optional_param(payload.ai_parallels);
+    let ai_examples = process_optional_param(payload.ai_examples);
+
     let insert_query = query!("INSERT INTO platform.topics (topic, is_verified, brief_description, full_description, 
-        ai_brief_description, ai_full_description) VALUES ($1, $2, $3, $4, $5, $6)",
+        bullet_points, examples, parallels, ai_brief_description, ai_full_description, ai_bullet_points, ai_parallels, 
+        ai_examples) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)",
     payload.topic,
     payload.is_verified,
     payload.brief_description,
     payload.full_description,
+    bullet_points.as_slice(),
+    examples.as_slice(),
+    parallels.as_slice(),
     payload.ai_brief_description,
     payload.ai_full_description,
+    ai_bullet_points.as_slice(),
+    ai_parallels.as_slice(),
+    ai_examples.as_slice(),
     );
     let insert_result = insert_query.execute(&db_pool).await;
     match insert_result {


### PR DESCRIPTION
Verified this works for both populated and non-populated array parameters:

POST endpoint:
```
localhost:3000/new-topic
```
Body:
```
{ 
    "topic":"pseudo-capitalism",
    "is_verified": true,
    "brief_description": "capitalism but pseudo",
    "bullet_points" : ["bullet1", "bullet2", "yadayada"]
}
```