### PR TITLE
Add logic to update bridge tables when creating new topics or terms

### DIFF
--- a/backend/crm_api/Cargo.toml
+++ b/backend/crm_api/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 [dependencies]
 axum = { version = "0.6.12", features = ["macros"] }
 dotenvy = "0.15.7"
+lazy_static = "1.4.0"
 serde = { version = "1.0.159", features = ["derive"] }
 sqlx = { version = "0.6.3", features = ["runtime-tokio-rustls", "postgres"] }
 tokio = { version = "1.26.0", features = ["macros", "rt-multi-thread"] }

--- a/backend/crm_api/src/helpers/handler_utils.rs
+++ b/backend/crm_api/src/helpers/handler_utils.rs
@@ -143,8 +143,8 @@ pub async fn build_bridge_tables(
         }
 
         let mut insert_query_str = format!(
-            "INSERT INTO platform.{} (term_id, topic_id) VALUES ",
-            bridge_table
+            "INSERT INTO platform.{} (term_id, {}_id) VALUES ",
+            bridge_table, entity_type
         );
 
         let mut param_index = 1;

--- a/backend/crm_api/src/helpers/handler_utils.rs
+++ b/backend/crm_api/src/helpers/handler_utils.rs
@@ -117,10 +117,10 @@ pub async fn build_bridge_tables(
         )
         .fetch_all(db_pool)
         .await?;
-    
+
         let bridge_table: &str;
-        if let Some(inner_key) = BRIDGE_TABLES.get(entity_type) {
-            if let Some(table_name) = BRIDGE_TABLES.get("term") {
+        if let Some(inner_hashmap) = BRIDGE_TABLES.get(entity_type) {
+            if let Some(table_name) = inner_hashmap.get("term") {
                 bridge_table = table_name;
             }
         }

--- a/backend/crm_api/src/routes/terms.rs
+++ b/backend/crm_api/src/routes/terms.rs
@@ -1,4 +1,4 @@
-use crate::helpers::handler_utils::{insert_topic_or_term, CreateTopicOrTerm};
+use crate::helpers::handler_utils::{build_bridge_tables, insert_topic_or_term, CreateTopicOrTerm};
 use axum::{
     extract::State,
     http::StatusCode,
@@ -102,6 +102,7 @@ pub async fn new_term_handler(
     Json(payload): Json<CreateTopicOrTerm>,
 ) -> Response {
     let insert_result = insert_topic_or_term(&payload, "term", &db_pool).await;
+    let _other_insert_result = build_bridge_tables(&payload, "term", &db_pool).await;
     match insert_result {
         Ok(_insert_result) => "new term created".into_response(),
         Err(error) => (StatusCode::INTERNAL_SERVER_ERROR, error.to_string()).into_response(),

--- a/backend/crm_api/src/routes/terms.rs
+++ b/backend/crm_api/src/routes/terms.rs
@@ -101,7 +101,7 @@ pub async fn new_term_handler(
     State(db_pool): State<PgPool>,
     Json(payload): Json<CreateTopicOrTerm>,
 ) -> Response {
-    let insert_result = insert_topic_or_term(payload, "term", &db_pool).await;
+    let insert_result = insert_topic_or_term(&payload, "term", &db_pool).await;
     match insert_result {
         Ok(_insert_result) => "new term created".into_response(),
         Err(error) => (StatusCode::INTERNAL_SERVER_ERROR, error.to_string()).into_response(),

--- a/backend/crm_api/src/routes/topics.rs
+++ b/backend/crm_api/src/routes/topics.rs
@@ -62,7 +62,12 @@ pub async fn new_topic_handler(
     State(db_pool): State<PgPool>,
     Json(payload): Json<CreateTopicOrTerm>,
 ) -> Response {
+
+
     let insert_result = insert_topic_or_term(payload, "topic", &db_pool).await;
+    // call new function here that builds bridge tables 
+    
+
     match insert_result {
         Ok(_insert_result) => "new topic created".into_response(),
         Err(error) => (StatusCode::INTERNAL_SERVER_ERROR, error.to_string()).into_response(),

--- a/backend/crm_api/src/routes/topics.rs
+++ b/backend/crm_api/src/routes/topics.rs
@@ -64,8 +64,7 @@ pub async fn new_topic_handler(
 ) -> Response {
     let insert_result = insert_topic_or_term(&payload, "topic", &db_pool).await;
     // todo: look up how I can do error handling for both of these function calls since they both return Result
-    let other_insert_result = build_bridge_tables(&payload, "topic", &db_pool).await;
-
+    let _other_insert_result = build_bridge_tables(&payload, "topic", &db_pool).await;
     match insert_result {
         Ok(_insert_result) => "new topic created".into_response(),
         Err(error) => (StatusCode::INTERNAL_SERVER_ERROR, error.to_string()).into_response(),

--- a/backend/crm_api/src/routes/topics.rs
+++ b/backend/crm_api/src/routes/topics.rs
@@ -1,4 +1,4 @@
-use crate::helpers::handler_utils::{insert_topic_or_term, CreateTopicOrTerm};
+use crate::helpers::handler_utils::{build_bridge_tables, insert_topic_or_term, CreateTopicOrTerm};
 use axum::{
     extract::State,
     http::StatusCode,
@@ -62,11 +62,9 @@ pub async fn new_topic_handler(
     State(db_pool): State<PgPool>,
     Json(payload): Json<CreateTopicOrTerm>,
 ) -> Response {
-
-
-    let insert_result = insert_topic_or_term(payload, "topic", &db_pool).await;
-    // call new function here that builds bridge tables 
-    
+    let insert_result = insert_topic_or_term(&payload, "topic", &db_pool).await;
+    // todo: look up how I can do error handling for both of these function calls since they both return Result
+    let other_insert_result = build_bridge_tables(&payload, "topic", &db_pool).await;
 
     match insert_result {
         Ok(_insert_result) => "new topic created".into_response(),


### PR DESCRIPTION
Added a new helper method that will update the `terms_to_topics` bridge table with calls to `/new-term` or `/new-topic`. Still need to update the bridge table update method to incorporate `sources`. 

**New Topic Example**:
```
POST localhost:3000/new-topic
BODY:
{ 
    "value":"deregulation",
    "is_verified": true,
    "brief_description": "the process of removing or reducing state regulations, typically in the economic sphere.",
    "bullet_points" : ["bullet1", "bullet2", "yadayada"],
    "examples": ["example1", "example2"],
    "related_terms": ["neoliberalism"]
}
```

subsequent call to `/terms-from-topic`:
```
localhost:3000/terms-from-topic?topic=deregulation
```
Returned data:
```
[
    {
        "id": 2,
        "term": "neoliberalism",
        "is_verified": false,
        "brief_description": "a term used to signify the late-20th century political reappearance of 19th-century ideas associated with free-market capitalism after it fell into decline following the Second World War",
        "full_description": null,
        "bullet_points": null,
        "examples": null,
        "parallels": null,
        "ai_brief_description": null,
        "ai_full_description": null,
        "ai_bullet_points": null,
        "ai_parallels": null,
        "ai_examples": null
    }
]
```

New Term Example:
```
POST localhost:3000/new-term
BODY
{ 
    "value":"laissez-faire",
    "is_verified": true,
    "brief_description": "a type of economic system in which transactions between private groups of people are free from any form of economic interventionism.",
    "bullet_points" : ["bullet1", "bullet2", "yadayada"],
    "examples": ["example1", "example2"],
    "related_topics": ["capitalism"]
}
```

Subsequent call to `GET localhost:3000/terms-from-topic?topic=capitalism`:
```
[
    {
        "id": 1,
        "term": "austerity",
        "is_verified": false,
        "brief_description": "difficult economic conditions created by government measures to reduce a budget deficit, especially by reducing public expenditure",
        "full_description": null,
        "bullet_points": null,
        "examples": null,
        "parallels": null,
        "ai_brief_description": null,
        "ai_full_description": null,
        "ai_bullet_points": null,
        "ai_parallels": null,
        "ai_examples": null
    },
    {
        "id": 2,
        "term": "neoliberalism",
        "is_verified": false,
        "brief_description": "a term used to signify the late-20th century political reappearance of 19th-century ideas associated with free-market capitalism after it fell into decline following the Second World War",
        "full_description": null,
        "bullet_points": null,
        "examples": null,
        "parallels": null,
        "ai_brief_description": null,
        "ai_full_description": null,
        "ai_bullet_points": null,
        "ai_parallels": null,
        "ai_examples": null
    },
    {
        "id": 3,
        "term": "laissez-faire",
        "is_verified": true,
        "brief_description": "a type of economic system in which transactions between private groups of people are free from any form of economic interventionism.",
        "full_description": null,
        "bullet_points": [
            "bullet1",
            "bullet2",
            "yadayada"
        ],
        "examples": [
            "example1",
            "example2"
        ],
        "parallels": [],
        "ai_brief_description": null,
        "ai_full_description": null,
        "ai_bullet_points": [],
        "ai_parallels": [],
        "ai_examples": []
    }
]
```