### PR TITLE
Basic `source` routes

### DIFF
--- a/backend/crm_api/src/helpers/handler_utils.rs
+++ b/backend/crm_api/src/helpers/handler_utils.rs
@@ -26,7 +26,7 @@ pub struct IdRow {
     id: i32,
 }
 
-pub fn process_optional_param(param: &Option<Vec<String>>) -> Vec<String> {
+pub fn process_optional_vec(param: &Option<Vec<String>>) -> Vec<String> {
     let mut processed_param = vec![];
     if let Some(populated_param) = param {
         // TODO: come back and update this method to output a reference instead
@@ -56,12 +56,12 @@ pub async fn insert_topic_or_term(
     topic_or_term: &str,
     db_pool: &PgPool,
 ) -> Result<()> {
-    let bullet_points = process_optional_param(&payload.bullet_points);
-    let examples = process_optional_param(&payload.examples);
-    let parallels = process_optional_param(&payload.parallels);
-    let ai_bullet_points = process_optional_param(&payload.ai_bullet_points);
-    let ai_parallels = process_optional_param(&payload.ai_parallels);
-    let ai_examples = process_optional_param(&payload.ai_examples);
+    let bullet_points = process_optional_vec(&payload.bullet_points);
+    let examples = process_optional_vec(&payload.examples);
+    let parallels = process_optional_vec(&payload.parallels);
+    let ai_bullet_points = process_optional_vec(&payload.ai_bullet_points);
+    let ai_parallels = process_optional_vec(&payload.ai_parallels);
+    let ai_examples = process_optional_vec(&payload.ai_examples);
 
     let query_string = format!("INSERT INTO platform.{}s ({}, is_verified, brief_description, full_description, 
         bullet_points, examples, parallels, ai_brief_description, ai_full_description, ai_bullet_points, ai_parallels, 
@@ -101,12 +101,12 @@ pub async fn build_bridge_tables(
         .fetch_one(db_pool)
         .await?;
 
-    let related_terms = process_optional_param(&payload.related_terms);
+    let related_terms = process_optional_vec(&payload.related_terms);
     let related_terms_str = related_terms.join(",");
-    let related_topics = process_optional_param(&payload.related_topics);
+    let related_topics = process_optional_vec(&payload.related_topics);
     let related_topics_str = related_topics.join(",");
     // TODO: implement sources logic.
-    let _related_sources = process_optional_param(&payload.related_sources);
+    let _related_sources = process_optional_vec(&payload.related_sources);
     let term_ids: Vec<i32>;
     let topic_ids: Vec<i32>;
 

--- a/backend/crm_api/src/routes/mod.rs
+++ b/backend/crm_api/src/routes/mod.rs
@@ -3,6 +3,7 @@ This file creates the routes.
 */
 
 mod hello_world;
+mod sources;
 mod terms;
 mod topics;
 use axum::{
@@ -11,6 +12,7 @@ use axum::{
     Router,
 };
 use hello_world::hello_world;
+use sources::get_all_sources_handler;
 use sqlx::postgres::PgPool;
 use terms::{get_all_terms_for_topic_handler, get_all_terms_handler, new_term_handler};
 use topics::{get_all_topics_handler, new_topic_handler};
@@ -29,5 +31,6 @@ pub fn create_routes(db_pool: PgPool) -> Router {
         .route("/terms-from-topic", get(get_all_terms_for_topic_handler))
         .route("/new-topic", post(new_topic_handler))
         .route("/new-term", post(new_term_handler))
+        .route("/sources", get(get_all_sources_handler))
         .with_state(app_state)
 }

--- a/backend/crm_api/src/routes/mod.rs
+++ b/backend/crm_api/src/routes/mod.rs
@@ -12,7 +12,7 @@ use axum::{
     Router,
 };
 use hello_world::hello_world;
-use sources::get_all_sources_handler;
+use sources::{get_all_sources_handler, new_source_handler};
 use sqlx::postgres::PgPool;
 use terms::{get_all_terms_for_topic_handler, get_all_terms_handler, new_term_handler};
 use topics::{get_all_topics_handler, new_topic_handler};
@@ -32,5 +32,6 @@ pub fn create_routes(db_pool: PgPool) -> Router {
         .route("/new-topic", post(new_topic_handler))
         .route("/new-term", post(new_term_handler))
         .route("/sources", get(get_all_sources_handler))
+        .route("/new-source", post(new_source_handler))
         .with_state(app_state)
 }

--- a/backend/crm_api/src/routes/sources.rs
+++ b/backend/crm_api/src/routes/sources.rs
@@ -40,6 +40,18 @@ pub struct Source {
     ai_generated: Option<bool>,
 }
 
+#[derive(Deserialize, FromRow)]
+pub struct CreateSource {
+    name: Option<String>,
+    url: Option<String>,
+    author: Option<String>,
+    author_url: Option<String>,
+    media_type: Option<MediaType>,
+    image_url: Option<String>,
+    image_type: Option<ImageType>,
+    ai_generated: Option<bool>,
+}
+
 /*
  /sources
 - returns all sources
@@ -70,4 +82,65 @@ pub async fn get_all_sources(db_pool: &PgPool) -> Result<Vec<Source>> {
     .fetch_all(db_pool)
     .await?;
     Ok(sources)
+}
+
+/*
+/new-source
+Body:
+{
+   "value": "<new_source_name>"
+}
+*/
+pub async fn new_source_handler(
+    State(db_pool): State<PgPool>,
+    Json(payload): Json<CreateSource>,
+) -> Response {
+    let insert_result = insert_source(&payload,  &db_pool).await;
+    // todo: update bridge tables when a new source is created as well
+    match insert_result {
+        Ok(_insert_result) => "new source created".into_response(),
+        Err(error) => (StatusCode::INTERNAL_SERVER_ERROR, error.to_string()).into_response(),
+    }
+}
+
+/*
+pub struct CreateSource {
+    name: Option<String>,
+    url: Option<String>,
+    author: Option<String>,
+    author_url: Option<String>,
+    media_type: Option<MediaType>,
+    image_url: Option<String>,
+    image_type: Option<ImageType>,
+    ai_generated: Option<bool>,
+}
+ */
+
+pub async fn insert_source(
+    payload: &CreateSource,
+    db_pool: &PgPool,
+) -> Result<()> {
+    let _insert_result = sqlx::query("
+                INSERT INTO platform.sources 
+                    (name,
+                    url,
+                    author,
+                    author_url,
+                    media_type,
+                    image_url,
+                    image_type,
+                    ai_generated) 
+                VALUES ($1, $2, $3, $4, $5, $6, $7, $8)")
+        .bind(&payload.name)
+        .bind(&payload.url)
+        .bind(&payload.author)
+        .bind(&payload.author_url)
+        .bind(&payload.media_type)
+        .bind(&payload.image_url)
+        .bind(&payload.image_type)
+        .bind(&payload.ai_generated)
+        .execute(db_pool)
+        .await;
+
+    Ok(())
 }

--- a/backend/crm_api/src/routes/sources.rs
+++ b/backend/crm_api/src/routes/sources.rs
@@ -103,19 +103,6 @@ pub async fn new_source_handler(
     }
 }
 
-/*
-pub struct CreateSource {
-    name: Option<String>,
-    url: Option<String>,
-    author: Option<String>,
-    author_url: Option<String>,
-    media_type: Option<MediaType>,
-    image_url: Option<String>,
-    image_type: Option<ImageType>,
-    ai_generated: Option<bool>,
-}
- */
-
 pub async fn insert_source(
     payload: &CreateSource,
     db_pool: &PgPool,

--- a/backend/crm_api/src/routes/sources.rs
+++ b/backend/crm_api/src/routes/sources.rs
@@ -1,0 +1,73 @@
+use axum::{
+    extract::State,
+    http::StatusCode,
+    response::{IntoResponse, Response},
+    Json,
+};
+use serde::{Deserialize, Serialize};
+use sqlx::{FromRow, PgPool, Result, Type};
+
+#[derive(Type, Serialize, Deserialize)]
+#[sqlx(type_name = "media_type", rename_all = "lowercase")]
+pub enum MediaType {
+    Audio,
+    Video,
+    Web,
+    Book,
+    ScientificArticle,
+}
+
+#[derive(Type, Serialize, Deserialize)]
+#[sqlx(type_name = "image_type", rename_all = "lowercase")]
+pub enum ImageType {
+    PDF,
+    PNG,
+    TIFF,
+    JPEG,
+    GIF,
+}
+
+#[derive(Serialize, Deserialize, FromRow)]
+pub struct Source {
+    id: i32,
+    name: Option<String>,
+    url: Option<String>,
+    author: Option<String>,
+    author_url: Option<String>,
+    media_type: Option<MediaType>,
+    image_url: Option<String>,
+    image_type: Option<ImageType>,
+    ai_generated: Option<bool>,
+}
+
+/*
+ /sources
+- returns all sources
+ */
+pub async fn get_all_sources_handler(State(db_pool): State<PgPool>) -> Response {
+    let sources = get_all_sources(&db_pool).await;
+    match sources {
+        Ok(sources) => (StatusCode::OK, Json(sources)).into_response(),
+        // for errors Axum expects the axum::response::Response type
+        // example output: error returned from database: relation "platform.tipics" does not exist
+        Err(error) => (StatusCode::INTERNAL_SERVER_ERROR, error.to_string()).into_response(),
+    }
+}
+
+pub async fn get_all_sources(db_pool: &PgPool) -> Result<Vec<Source>> {
+    let sources = sqlx::query_as::<_, Source>(
+        "SELECT id,
+        name,
+        url,
+        author,
+        author_url,
+        media_type,
+        image_url,
+        image_type,
+        ai_generated
+    FROM platform.sources",
+    )
+    .fetch_all(db_pool)
+    .await?;
+    Ok(sources)
+}

--- a/backend/crm_api/src/routes/topics.rs
+++ b/backend/crm_api/src/routes/topics.rs
@@ -55,7 +55,7 @@ pub async fn get_all_topics(db_pool: &PgPool) -> Result<Vec<Topic>> {
 /new-topic
 Body:
 {
-   "topic": "<new_topic_name>"
+   "value": "<new_topic_name>"
 }
 */
 pub async fn new_topic_handler(


### PR DESCRIPTION
* new route: `/sources` -- returns all sources
* new route: `/new-source` -- creates a new source 

Note: since `media_type` and `image_type` are enums in Postgres as well as rust, you have to specify them with the exact spelling from the code. e.g. `Web` or `PDF`. 

Example of `/new-source`:
```
POST localhost:3000/new-source
```
BODY
```
{
    "name": "new_source",
    "media_type": "Web",
    "image_type": "PDF"
}
```

using `/sources` after:
```
GET localhost:3000/sources
```
Returns:
```
[
    {
        "id": 1,
        "name": null,
        "url": "https://www.merriam-webster.com/dictionary/austerity",
        "author": null,
        "author_url": null,
        "media_type": "Web",
        "image_url": null,
        "image_type": null,
        "ai_generated": false
    },
    {
        "id": 2,
        "name": null,
        "url": "https://en.wikipedia.org/wiki/Neoliberalism",
        "author": null,
        "author_url": null,
        "media_type": "Web",
        "image_url": null,
        "image_type": null,
        "ai_generated": false
    },
    {
        "id": 3,
        "name": null,
        "url": "https://en.wikipedia.org/wiki/Capitalism",
        "author": null,
        "author_url": null,
        "media_type": "Web",
        "image_url": null,
        "image_type": null,
        "ai_generated": false
    },
    {
        "id": 4,
        "name": "new_source",
        "url": null,
        "author": null,
        "author_url": null,
        "media_type": "Web",
        "image_url": null,
        "image_type": "PDF",
        "ai_generated": null
    }
]
```