### PR TITLE
Support for adding in `related_sources` 

### DIFF
--- a/backend/crm_api/database/init.sql
+++ b/backend/crm_api/database/init.sql
@@ -11,7 +11,7 @@ CREATE TYPE image_type AS ENUM ('pdf', 'png', 'tiff', 'jpeg', 'gif');
 
 CREATE TABLE platform.sources (
 	id serial NOT NULL,
-	name text,
+	name text NOT NULL,
 	url text,
 	author text,
 	author_url text,
@@ -156,9 +156,9 @@ CREATE TABLE platform.related_topics (
 
 -- we don't need to specify the `id` column bc it is serial 
 -- so it will auto-increment
-INSERT INTO platform.sources (url, media_type, ai_generated) VALUES ('https://www.merriam-webster.com/dictionary/austerity', 'web', 'false');
-INSERT INTO platform.sources (url, media_type, ai_generated) VALUES ('https://en.wikipedia.org/wiki/Neoliberalism', 'web', 'false');
-INSERT INTO platform.sources (url, media_type, ai_generated) VALUES ('https://en.wikipedia.org/wiki/Capitalism', 'web', 'false');
+INSERT INTO platform.sources (name, url, media_type, ai_generated) VALUES ('dictionary austerity', 'https://www.merriam-webster.com/dictionary/austerity', 'web', 'false');
+INSERT INTO platform.sources (name, url, media_type, ai_generated) VALUES ('wikipedia neoliberalism', 'https://en.wikipedia.org/wiki/Neoliberalism', 'web', 'false');
+INSERT INTO platform.sources (name, url, media_type, ai_generated) VALUES ('wikipedia capitalism', 'https://en.wikipedia.org/wiki/Capitalism', 'web', 'false');
 
 INSERT INTO platform.topics (topic, brief_description) VALUES ('capitalism', ' an economic system based on the private ownership of the means of production and their operation for profit.');
 

--- a/backend/crm_api/src/helpers/handler_utils.rs
+++ b/backend/crm_api/src/helpers/handler_utils.rs
@@ -135,9 +135,6 @@ pub async fn insert_topic_or_term(
     Ok(())
 }
 
-// payload can either be CreateTopicOrTerm or CreateSource
-// in order for &T to work, I need to define shared behavior:
-// each struct has .name, .related_sources, .related_terms, .related_topics fields
 pub async fn build_bridge_tables<T: CreateEntity>(
     payload: &T,
     entity_type: &str,

--- a/backend/crm_api/src/helpers/handler_utils.rs
+++ b/backend/crm_api/src/helpers/handler_utils.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 #[derive(Deserialize, FromRow)]
 pub struct CreateTopicOrTerm {
     name: String,
-    is_verified: Option<bool>,
+    is_verified: bool,
     brief_description: Option<String>,
     full_description: Option<String>,
     bullet_points: Option<Vec<String>>,

--- a/backend/crm_api/src/helpers/mod.rs
+++ b/backend/crm_api/src/helpers/mod.rs
@@ -1,1 +1,2 @@
 pub mod handler_utils;
+pub mod shared_types;

--- a/backend/crm_api/src/helpers/shared_types.rs
+++ b/backend/crm_api/src/helpers/shared_types.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use sqlx::FromRow;
+use sqlx::{FromRow, Type};
 
 #[derive(Type, Serialize, Deserialize)]
 #[sqlx(type_name = "media_type", rename_all = "lowercase")]

--- a/backend/crm_api/src/helpers/shared_types.rs
+++ b/backend/crm_api/src/helpers/shared_types.rs
@@ -1,0 +1,41 @@
+use serde::{Deserialize, Serialize};
+use sqlx::FromRow;
+
+#[derive(Type, Serialize, Deserialize)]
+#[sqlx(type_name = "media_type", rename_all = "lowercase")]
+pub enum MediaType {
+    Audio,
+    Video,
+    Web,
+    Book,
+    ScientificArticle,
+}
+
+#[derive(Type, Serialize, Deserialize)]
+#[sqlx(type_name = "image_type", rename_all = "lowercase")]
+pub enum ImageType {
+    PDF,
+    PNG,
+    TIFF,
+    JPEG,
+    GIF,
+}
+
+#[derive(Deserialize, FromRow)]
+pub struct CreateSource {
+    pub name: String,
+    pub url: Option<String>,
+    pub author: Option<String>,
+    pub author_url: Option<String>,
+    pub media_type: Option<MediaType>,
+    pub image_url: Option<String>,
+    pub image_type: Option<ImageType>,
+    pub ai_generated: Option<bool>,
+    pub related_terms: Option<Vec<String>>,
+    pub related_topics: Option<Vec<String>>,
+    pub related_sources: Option<Vec<String>>,
+}
+
+/*
+I need to import the above into handler_utils as well as sources.rs
+ */

--- a/backend/crm_api/src/routes/sources.rs
+++ b/backend/crm_api/src/routes/sources.rs
@@ -7,7 +7,7 @@ use axum::{
     Json,
 };
 use serde::{Deserialize, Serialize};
-use sqlx::{FromRow, PgPool, Result, Type};
+use sqlx::{FromRow, PgPool, Result};
 
 #[derive(Serialize, Deserialize, FromRow)]
 pub struct Source {

--- a/backend/crm_api/src/routes/topics.rs
+++ b/backend/crm_api/src/routes/topics.rs
@@ -60,7 +60,7 @@ pub async fn get_all_topics(db_pool: &PgPool) -> Result<Vec<Topic>> {
 /new-topic
 Body:
 {
-   "value": "<new_topic_name>"
+   "name": "<new_topic_name>"
 }
 */
 pub async fn new_topic_handler(
@@ -75,7 +75,6 @@ pub async fn new_topic_handler(
         Err(error) => (StatusCode::INTERNAL_SERVER_ERROR, error.to_string()).into_response(),
     }
 }
-
 
 pub async fn get_topic_handler(
     State(db_pool): State<PgPool>,


### PR DESCRIPTION
Proof that inserting source with related terms/topics works:

```
localhost:3000/new-source
{
    "name": "new_source3",
    "media_type": "Web",
    "image_type": "PDF",
    "related_terms": ["austerity"],
    "related_topics": ["capitalism"]
}

platform=# select * from platform.topics_to_sources;
 topic_id | source_id
----------+-----------
        1 |         3
        1 |         6
(2 rows)

platform=# select * from platform.terms_to_sources;
 term_id | source_id
---------+-----------
       1 |         1
       2 |         2
       1 |         6
(3 rows)
```

Proof that inserting new term with related sources works:
```
localhost:3000/new-term
{
    "name": "new_term2",
    "is_verified": false,
    "related_topics": ["capitalism"],
    "related_sources": ["dictionary austerity"]
}


platform=# select * from platform.terms_to_sources;
 term_id | source_id
---------+-----------
       1 |         1
       2 |         2
       1 |         6
       4 |         1
(4 rows)
```

Proof that inserting new topic with related sources works:
```
localhost:3000/new-topic
{
    "name": "new_topic1",
    "is_verified": false,
    "related_terms": ["new_term2"],
    "related_sources": ["dictionary austerity"]
}

platform=# select * from platform.topics_to_sources;
 topic_id | source_id
----------+-----------
        1 |         3
        1 |         6
        2 |         1
(3 rows)
```

